### PR TITLE
Only return persisted consent data from CMP commands

### DIFF
--- a/src/lib/cmp.js
+++ b/src/lib/cmp.js
@@ -35,9 +35,15 @@ export default class Cmp {
 		 * Get the encoded vendor consent data value.
 		 */
 		getConsentData: (_, callback=() => {}) => {
-			callback(encodeVendorConsentData({
-				...this.store.vendorConsentData,
-				vendorList: this.store.vendorList
+			const {
+				persistedVendorConsentData,
+				vendorList
+			} = this.store;
+
+			// Encode the persisted data
+			callback(persistedVendorConsentData && encodeVendorConsentData({
+				...persistedVendorConsentData,
+				vendorList
 			}));
 		},
 

--- a/src/lib/cmp.test.js
+++ b/src/lib/cmp.test.js
@@ -34,6 +34,19 @@ describe('cmp', () => {
 			});
 		});
 
+		it('getPublisherConsents returns only persisted data', (done) => {
+			cmp.store.selectPurpose(1, true);
+			cmp.processCommand('getPublisherConsents', null, data => {
+				expect(data.standardPurposes['1']).to.be.false;
+				cmp.store.persist();
+
+				cmp.processCommand('getPublisherConsents', null, data => {
+					expect(data.standardPurposes['1']).to.be.true;
+					done();
+				});
+			});
+		});
+
 		it('getVendorConsents executes', (done) => {
 			cmp.processCommand('getVendorConsents', null, data => {
 				expect(Object.keys(data.purposes).length).to.equal(vendorList.purposes.length);
@@ -42,7 +55,28 @@ describe('cmp', () => {
 			});
 		});
 
+		it('getVendorConsents returns only persisted data', (done) => {
+			cmp.store.selectVendor(1, true);
+			cmp.processCommand('getVendorConsents', null, data => {
+				expect(data.vendorConsents['1']).to.be.false;
+				cmp.store.persist();
+
+				cmp.processCommand('getVendorConsents', null, data => {
+					expect(data.vendorConsents['1']).to.be.true;
+					done();
+				});
+			});
+		});
+
 		it('getConsentData executes', (done) => {
+			cmp.processCommand('getConsentData', null, data => {
+				expect(data).to.be.undefined;
+				done();
+			});
+		});
+
+		it('getConsentData returns persisted data', (done) => {
+			cmp.store.persist();
 			cmp.processCommand('getConsentData', null, data => {
 				expect(typeof data).to.equal('string');
 				expect(data).to.not.be.empty;

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -3,6 +3,10 @@ import config from './config';
 
 export default class Store {
 	constructor({ vendorConsentData, publisherConsentData, vendorList, customPurposeList }={}) {
+		// Keep track of data that has already been persisted
+		this.persistedVendorConsentData = vendorConsentData;
+		this.persistedPublisherConsentData = publisherConsentData;
+
 		const {
 			vendors = [],
 			purposes: vendorPurposes = [],
@@ -34,10 +38,13 @@ export default class Store {
 		this.isConsentToolShowing = false;
 	}
 
+	/**
+	 * Build vendor consent object from data that has already been persisted.
+	 */
 	getVendorConsentsObject = (vendorIds) => {
 		const {
 			vendorList = {},
-			vendorConsentData
+			persistedVendorConsentData = {}
 		} = this;
 
 		const {
@@ -47,9 +54,9 @@ export default class Store {
 			cmpId,
 			vendorListVersion,
 			maxVendorId,
-			selectedVendorIds,
-			selectedPurposeIds
-		} = vendorConsentData;
+			selectedVendorIds = new Set(),
+			selectedPurposeIds = new Set()
+		} = persistedVendorConsentData;
 
 		const { purposes = [], vendors = []} = vendorList;
 
@@ -76,12 +83,15 @@ export default class Store {
 		};
 	};
 
+	/**
+	 * Build publisher consent object from data that has already been persisted
+	 */
 	getPublisherConsentsObject = () => {
 		const {
 			vendorList = {},
 			customPurposeList = {},
-			publisherConsentData,
-			vendorConsentData
+			persistedPublisherConsentData = {},
+			persistedVendorConsentData = {}
 		} = this;
 
 		const {
@@ -91,10 +101,10 @@ export default class Store {
 			cmpId,
 			vendorListVersion,
 			publisherPurposeVersion,
-			selectedCustomPurposeIds
-		} = publisherConsentData;
+			selectedCustomPurposeIds = new Set()
+		} = persistedPublisherConsentData;
 
-		const { selectedPurposeIds } = vendorConsentData;
+		const { selectedPurposeIds = new Set() } = persistedVendorConsentData;
 		const { purposes = [] } = vendorList;
 		const { purposes: customPurposes = []} = customPurposeList;
 
@@ -143,6 +153,10 @@ export default class Store {
 				customPurposeList
 			});
 		}
+
+		// Store the persisted data
+		this.persistedVendorConsentData = {...vendorConsentData};
+		this.persistedPublisherConsentData = {...publisherConsentData};
 
 		// Notify of date changes
 		this.storeUpdate();


### PR DESCRIPTION
CMP commands: getPublisherConsents, getVendorConsents and getConsentData currently return the current state of the consent data (including defaults).  This PR changes them to only return what has been persisted to the cookie.