### PR TITLE
Default storing consent on first-party domain

### DIFF
--- a/src/docs/components/examples/basic/vendorConsents.jsx
+++ b/src/docs/components/examples/basic/vendorConsents.jsx
@@ -1,7 +1,7 @@
 import Example from "../example";
 
 const execute =
-	`window.__cmp('getVendorConsents', [0,1,2,3,4], function(result){
+	`window.__cmp('getVendorConsents', [1,2,3,4], function(result){
 	myLogger('getVendorConsents callback result:\\n' + JSON.stringify(result, null, 2));
 });`;
 

--- a/src/docs/lib/dropscript.js
+++ b/src/docs/lib/dropscript.js
@@ -33,8 +33,8 @@ function buildScript(config, cmpLocation='../cmp.bundle.js') {
 					//
 					// customPurposeListLocation: './purposes.json',
 					// globalConsentLocation: './portal.html',
-					// storeConsentGlobally: true,
-					// storePublisherData: true,
+					// storeConsentGlobally: false,
+					// storePublisherData: false,
 					// logging: 'debug',
 					// localization: {},
 					// forceLocale: 'en-us'

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -3,7 +3,7 @@ import log from './log';
 const defaultConfig = {
 	customPurposeListLocation: './purposes.json',
 	globalConsentLocation: './portal.html',
-	storeConsentGlobally: true,
+	storeConsentGlobally: false,
 	storePublisherData: false,
 	logging: false,
 	localization: {},

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -2,7 +2,7 @@ import { writePublisherConsentCookie, writeVendorConsentCookie } from "./cookie/
 import config from './config';
 
 export default class Store {
-	constructor({ vendorConsentData, publisherConsentData, vendorList, customPurposeList }={}) {
+	constructor({vendorConsentData, publisherConsentData, vendorList, customPurposeList} = {}) {
 		// Keep track of data that has already been persisted
 		this.persistedVendorConsentData = vendorConsentData;
 		this.persistedPublisherConsentData = publisherConsentData;
@@ -53,17 +53,41 @@ export default class Store {
 			lastUpdated,
 			cmpId,
 			vendorListVersion,
-			maxVendorId,
+			maxVendorId = 0,
 			selectedVendorIds = new Set(),
 			selectedPurposeIds = new Set()
 		} = persistedVendorConsentData;
 
-		const { purposes = [], vendors = []} = vendorList;
+		const {purposes = [], vendors = []} = vendorList;
 
-		// If no vendor ID list is supplied return all vendors
-		const vendorIdList = vendors
-			.map(({ id }) => id)
-			.filter(id => !vendorIds || vendorIds.indexOf(id) > -1);
+
+		// Map requested vendorIds
+		const vendorMap = {};
+		if (vendorIds && vendorIds.length) {
+			vendorIds.forEach(id => vendorMap[id] = selectedVendorIds.has(id));
+		}
+		else {
+			// In case the vendor list has not been loaded yet find the highest
+			// vendor ID to map any consent data we already have
+			const lastVendorId = Math.max(maxVendorId,
+				...vendors.map(({id}) => id),
+				...Array.from(selectedVendorIds));
+
+			// Map all IDs up to the highest vendor ID found
+			for (let i = 1; i <= lastVendorId; i++) {
+				vendorMap[i] = selectedVendorIds.has(i);
+			}
+		}
+
+		// Map all purpose IDs
+		const lastPurposeId = Math.max(
+			...purposes.map(({id}) => id),
+			...Array.from(selectedPurposeIds));
+
+		const purposeMap = {};
+		for (let i = 1; i <= lastPurposeId; i++) {
+			purposeMap[i] = selectedPurposeIds.has(i);
+		}
 
 		return {
 			cookieVersion,
@@ -72,14 +96,8 @@ export default class Store {
 			cmpId,
 			vendorListVersion,
 			maxVendorId,
-			purposes: purposes.reduce((acc, { id }) => ({
-				...acc,
-				[id]: selectedPurposeIds.has(id)
-			}), {}),
-			vendorConsents: vendorIdList.reduce((acc, vendorId) => ({
-				...acc,
-				[vendorId]: selectedVendorIds.has(vendorId)
-			}), {})
+			purposes: purposeMap,
+			vendorConsents: vendorMap
 		};
 	};
 
@@ -104,9 +122,28 @@ export default class Store {
 			selectedCustomPurposeIds = new Set()
 		} = persistedPublisherConsentData;
 
-		const { selectedPurposeIds = new Set() } = persistedVendorConsentData;
-		const { purposes = [] } = vendorList;
-		const { purposes: customPurposes = []} = customPurposeList;
+		const {selectedPurposeIds = new Set()} = persistedVendorConsentData;
+		const {purposes = []} = vendorList;
+		const {purposes: customPurposes = []} = customPurposeList;
+
+
+		const lastStandardPurposeId = Math.max(
+			...purposes.map(({id}) => id),
+			...Array.from(selectedPurposeIds));
+
+		const lastCustomPurposeId = Math.max(
+			...customPurposes.map(({id}) => id),
+			...Array.from(selectedPurposeIds));
+
+		// Map all purpose IDs
+		const standardPurposeMap = {};
+		for (let i = 1; i <= lastStandardPurposeId; i++) {
+			standardPurposeMap[i] = selectedPurposeIds.has(i);
+		}
+		const customPurposeMap = {};
+		for (let i = 1; i <= lastCustomPurposeId; i++) {
+			customPurposeMap[i] = selectedCustomPurposeIds.has(i);
+		}
 
 		return {
 			cookieVersion,
@@ -115,14 +152,8 @@ export default class Store {
 			cmpId,
 			vendorListVersion,
 			publisherPurposeVersion,
-			standardPurposes: purposes.reduce((acc, { id }) => ({
-				...acc,
-				[id]: selectedPurposeIds.has(id)
-			}), {}),
-			customPurposes: customPurposes.reduce((acc, { id }) => ({
-				...acc,
-				[id]: selectedCustomPurposeIds.has(id)
-			}), {})
+			standardPurposes: standardPurposeMap,
+			customPurposes: customPurposeMap
 		};
 	};
 
@@ -143,7 +174,7 @@ export default class Store {
 		publisherConsentData.lastUpdated = now;
 
 		// Write vendor cookie to appropriate domain
-		writeVendorConsentCookie({ ...vendorConsentData, vendorList });
+		writeVendorConsentCookie({...vendorConsentData, vendorList});
 
 		// Write publisher cookie if enabled
 		if (config.storePublisherData) {
@@ -177,7 +208,7 @@ export default class Store {
 	};
 
 	selectVendor = (vendorId, isSelected) => {
-		const { selectedVendorIds } = this.vendorConsentData;
+		const {selectedVendorIds} = this.vendorConsentData;
 		if (isSelected) {
 			selectedVendorIds.add(vendorId);
 		}
@@ -195,7 +226,7 @@ export default class Store {
 	};
 
 	selectPurpose = (purposeId, isSelected) => {
-		const { selectedPurposeIds } = this.vendorConsentData;
+		const {selectedPurposeIds} = this.vendorConsentData;
 		if (isSelected) {
 			selectedPurposeIds.add(purposeId);
 		}
@@ -213,7 +244,7 @@ export default class Store {
 	};
 
 	selectCustomPurpose = (purposeId, isSelected) => {
-		const { selectedCustomPurposeIds } = this.publisherConsentData;
+		const {selectedCustomPurposeIds} = this.publisherConsentData;
 		if (isSelected) {
 			selectedCustomPurposeIds.add(purposeId);
 		}
@@ -235,4 +266,13 @@ export default class Store {
 		this.storeUpdate();
 	};
 
+	updateVendorList = vendorList => {
+		this.vendorList = vendorList;
+		this.storeUpdate();
+	};
+
+	updateCustomPurposeList = customPurposeList => {
+		this.customPurposeList = customPurposeList;
+		this.storeUpdate();
+	};
 }

--- a/src/lib/store.test.js
+++ b/src/lib/store.test.js
@@ -94,7 +94,7 @@ describe('store', () => {
 		const store = new Store({
 			vendorList,
 			vendorConsentData: {
-				selectedVendorIds: new Set([8, 10]),
+				selectedVendorIds: new Set([2, 4]),
 			}
 		});
 


### PR DESCRIPTION
- Change default storeConsentGlobally to false
- Do not wait for vendor.json to finish loading before applying full CMP implementation and announcing `isLoaded`