### PR TITLE
Proces the command queue after the vendor and purpose lists are fetched

### DIFF
--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -59,16 +59,15 @@ export function init(configUpdates) {
 			const App = require('../components/app').default;
 			render(<App store={store} notify={cmp.notify} />, document.body);
 
-
-			// Execute any previously queued command
-			cmp.commandQueue = commandQueue;
-			cmp.processCommandQueue();
-
 			// Request lists
 			return Promise.all([
 				fetchGlobalVendorList().then(store.updateVendorList),
 				fetchPurposeList().then(store.updateCustomPurposeList)
 			]).then(() => {
+				// Execute any previously queued command
+				cmp.commandQueue = commandQueue;
+				cmp.processCommandQueue();
+
 				cmp.cmpReady = true;
 				cmp.notify('cmpReady');
 			}).catch(err => {


### PR DESCRIPTION
Otherwise, if the command `getVendorList` is in the queue, it will get called before the list is fetched and the callback will return `undefined`.

Since I don't know the code very well, I am wondering if we actually need to wait for _both_ `fetchPurposeList` and `fetchGlobalVendorList`.
Otherwise I would do it directly in the `then()` of `fetchGlobalVendorList()`.