### PR TITLE
Command queue

### DIFF
--- a/src/complete.js
+++ b/src/complete.js
@@ -71,7 +71,7 @@ function addLocatorFrame() {
 addLocatorFrame();
 
 // Add stub
-const commandQueue = [];
+const {commandQueue = []} = window[CMP_GLOBAL_NAME] || {};
 const cmp = function (command, parameter, callback) {
 	commandQueue.push({
 		command,

--- a/src/complete.js
+++ b/src/complete.js
@@ -93,13 +93,13 @@ cmp.receiveMessage = function (event) {
 	}
 };
 
-window.__cmp = cmp;
+window[CMP_GLOBAL_NAME] = cmp;
 
 // Listen for postMessage events
 const listen = window.attachEvent || window.addEventListener;
 listen('message', event => {
-	window.__cmp.receiveMessage(event);
+	window[CMP_GLOBAL_NAME].receiveMessage(event);
 }, false);
 
 // Initialize CMP and then check if we need to ask for consent
-init(configUpdates).then(() => checkConsent(window.__cmp));
+init(configUpdates).then(() => checkConsent(window[CMP_GLOBAL_NAME]));


### PR DESCRIPTION
@krishoyt: I know that I have already created pull request #50 which was declined. But please consider it one more time. If you decline it again I will understand and promise not to bother you anymore ;-)

I understand that I should create my own stub of `__cmp` object because "cmp.complete.bundle.js" is only an example. But why not to provide with *Consent Tool* library some builtin script that implements common use case? In may opinion "cmp.complete.bundle.js" is quite sufficient for most website owners in EU. By changing only one line it may be used on real website even in **full asynchronous mode** without need to duplicate the same `__cmp` stub in every single document of website.

```html
<script>
// Note: below code may be moved to external file and load in async mode
// before or after "/cmp/cmp.complete.bundle.js"

function callCmpApi(command, parameter, callback) {
    if (window.__cmp && typeof window.__cmp === 'function') {
        window.__cmp(command, parameter, function (result) {
            typeof callback === 'function' && callback(result);
        });
    } else {
        window.__cmp = window.__cmp || {};
        window.__cmp.commandQueue = window.__cmp.commandQueue || [];
        window.__cmp.commandQueue.push({
            command: command,
            parameter: parameter,
            callback: function (result) {
                typeof callback === 'function' && callback(result);
            }
        });
    }
}

callCmpApi('addEventListener', 'cmpReady', function () {
    // Do something here...
});
</script>
<script src="/cmp/cmp.complete.bundle.js" async></script>
```

Even if you are not sure whether changes from this pull request are good or bad please notice that merging it rather won't harm your code anyhow.