### PR TITLE
Ensure CMP banner is not visible when consents have been already gathered

### DIFF
--- a/src/components/banner/banner.jsx
+++ b/src/components/banner/banner.jsx
@@ -73,7 +73,7 @@ export default class Banner extends Component {
 			<div
 				ref={el => this.bannerRef = el}
 				class={style.banner}
-				style={{bottom: `${bannerBottom}px`}}
+				style={{bottom: `${bannerBottom}px`, visibility: isShowing ? 'visible' : 'hidden'}}
 			>
 				<div class={style.content}>
 					<div


### PR DESCRIPTION
I've noticed that on mobile devices with narrow screen top part of CMP banner is visible even if consents have been already gathered. May be it's because translation which I use contains longer text that is displayed on banner. Anyhow setting "visibility: hidden" resolves this issue. Note: setting "display: none" breaks slide-up animation of banner on desktop - that's why I used "visibility" not "display" property.