### PR TITLE
add expires to writeCookie, solve ie11win7 cookie issue

### DIFF
--- a/src/lib/cookie/cookie.js
+++ b/src/lib/cookie/cookie.js
@@ -204,7 +204,8 @@ function readCookie(name) {
 
 function writeCookie(name, value, maxAgeSeconds, path = '/') {
 	const maxAge = maxAgeSeconds === null ? '' : `;max-age=${maxAgeSeconds}`;
-	document.cookie = `${name}=${value};path=${path}${maxAge}`;
+	const expires = maxAgeSeconds === null ? '' : ';expires=' + new Date(new Date() * 1 + maxAgeSeconds * 1000).toUTCString();
+	document.cookie = `${name}=${value};path=${path}${maxAge}${expires}`;
 }
 
 function readPublisherConsentCookie() {


### PR DESCRIPTION
The cookie will be removed after the session finished on IE11, Win7. Need to set the expires for it.