### PR TITLE
Pass "success" within __cmpReturn

### DIFF
--- a/src/lib/cmp.js
+++ b/src/lib/cmp.js
@@ -207,12 +207,13 @@ export default class Cmp {
 			queue.forEach(({ callId, command, parameter, callback, event }) => {
 				// If command is queued with an event we will relay its result via postMessage
 				if (event) {
-					this.processCommand(command, parameter, returnValue =>
+					this.processCommand(command, parameter, (returnValue, success) =>
 						event.source.postMessage({
 							[CMP_RETURN_NAME]: {
 								callId,
 								command,
-								returnValue
+								returnValue,
+								success
 							}
 						}, event.origin));
 				}
@@ -231,12 +232,13 @@ export default class Cmp {
 		const { [CMP_CALL_NAME]: cmp } = data;
 		if (cmp) {
 			const { callId, command, parameter } = cmp;
-			this.processCommand(command, parameter, returnValue =>
+			this.processCommand(command, parameter, (returnValue, success) =>
 				source.postMessage({
 					[CMP_RETURN_NAME]: {
 						callId,
 						command,
-						returnValue
+						returnValue,
+						success
 					}
 				}, origin));
 		}


### PR DESCRIPTION
Pass down "success" within __cmpResult for postMessage communication with CMP as documented in 
https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/CMP%20JS%20API%20v1.1%20Final.md#without-safeframes-using-postmessage-

Fixes #116 