### PR TITLE
Document Config Defaults

### DIFF
--- a/src/components/popup/details/vendors/vendors.jsx
+++ b/src/components/popup/details/vendors/vendors.jsx
@@ -78,7 +78,7 @@ export default class Vendors extends Component {
 					</div>
 				</div>
 				<div class={detailsStyle.description} style={{color: textLightColor}}>
-					<p><PurposesLabel localizeKey={`purpose${selectedPurposeId}.description`}>What this means: {description}</PurposesLabel></p>
+					<p><PurposesLabel localizeKey={`purpose${selectedPurposeId}.description`}>{description}</PurposesLabel></p>
 					<p><PurposesLabel localizeKey='optoutdDescription'>
 						Depending on the type of data they collect, use,
 						and process and other factors including privacy by design, certain partners rely on your consent while others require you to opt-out.

--- a/src/docs/components/docs/configuration.jsx
+++ b/src/docs/components/docs/configuration.jsx
@@ -75,9 +75,23 @@ export default class CmpApi extends Component {
 							</span>
 						</span>
 						<span class={style.argument}>
+							<span class={style.argumentType}>localization (Object)</span>:
+							<span class={style.argumentDescription}>
+								Localization options. An important note: The translations.js file will be used to present legally important information for languages other than English, which
+								means you will need to keep non-English translations updated with the latest non-English equivalent language. The default 'purposes' language for English is pulled
+								from the vendorlist.json in this example.
+							</span>
+						</span>
+						<span class={style.argument}>
+							<span class={style.argumentType}>forceLocale (String)</span>:
+							<span class={style.argumentDescription}>
+								Overrides user browser locale indications and instead uses the given locale, e.g. 'en-us'
+							</span>
+						</span>
+						<span class={style.argument}>
 							<span class={style.argumentType}>allowedVendorIds (Array[number])</span>:
 							<span class={style.argumentDescription}>
-								White list of vendor IDs to display and persist data for in the CMP.  This will override a list provided
+								Allow list of vendor IDs to display and persist data for in the CMP.  This will override a list provided
 								by pubvendors.json.
 							</span>
 						</span>

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,6 +1,6 @@
 import log from './log';
 
-// These options are documented at http://acdn.origin.appnexus.net/cmp/docs/#/config.
+// These options are documented at https://acdn.adnxs.com/cmp/docs/#/config
 // We highly recommend reading the options as the defaults may not fit your goals.
 const defaultConfig = {
 	customPurposeListLocation: './purposes.json',

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,7 +1,10 @@
 import log from './log';
 
+// These options are documented at http://acdn.origin.appnexus.net/cmp/docs/#/config.
+// We highly recommend reading the options as the defaults may not fit your goals.
 const defaultConfig = {
 	customPurposeListLocation: './purposes.json',
+	// The location of the latest vendorlist to use.
 	globalVendorListLocation: 'https://vendorlist.consensu.org/vendorlist.json',
 	globalConsentLocation: './portal.html',
 	storeConsentGlobally: false,

--- a/src/lib/translations.js
+++ b/src/lib/translations.js
@@ -2,7 +2,9 @@
  * The default set of translated pieces of text indexed by locale.
  * Values from window.__cmp.config.localization will override these
  * per locale.  Empty values will use the english value provided
- * inline in each component.
+ * inline in each component. Because the purpose definitions will change,
+ * you will need to update the translations regularly. As a consequence, this
+ * translations.js file is very important to keep up to date.
  */
 export default {
 	en: {
@@ -44,34 +46,16 @@ export default {
 			back: '',
 			optoutdDescription: ``,
 			purpose1: {
-				description: `Allow storing or accessing information on a user's device.`
+				description: ''
 			},
 			purpose2: {
-				description: `Allow processing of a user's data to provide and inform personalised advertising (including delivery, measurement, and reporting) based on a user's preferences or interests known or inferred from data collected across multiple sites, apps, or devices; and/or accessing or storing information on devices  for that purpose.
-				Will include following Features:
-				<ul>
-					<li>Matching Data to Offline Sources - combining data from offline sources that were initially collected in other contexts.</li>
-					<li>Linking Devices - allow processing of a user's data to connect such user across multiple devices.</li>
-					<li>Precise Geographic Location data - allow processing of a user's precise geographic location data in support of a purpose for which that certain third party has consent.</li>
-				</ul>`
+				description: ''
 			},
 			purpose3: {
-				description: `Allow processing of a user's data to deliver content or advertisements and measure the delivery of such content or advertisements, extract insights and generate reports to understand service usage; and/or accessing or storing information on devices for that purpose.
-				Will include following Features:
-				<ul>
-					<li>Matching Data to Offline Sources - combining data from offline sources that were initially collected in other contexts.</li>
-					<li>Linking Devices - allow processing of a user's data to connect such user across multiple devices.</li>
-					<li>Precise Geographic Location data - allow processing of a user's precise geographic location data in support of a purpose for which that certain third party has consent.</li>
-				</ul>`
+				description: ''
 			},
 			purpose4: {
-				description: `Allow processing of a user's data to provide and inform personalised content (including delivery, measurement, and reporting) based on a user's preferences or interests known or inferred from data collected across multiple sites, apps, or devices; and/or accessing or storing information on devices for that purpose.
-				Will include following Features:
-				<ul>
-					<li>Matching Data to Offline Sources - combining data from offline sources that were initially collected in other contexts.</li>
-					<li>Linking Devices - allow processing of a user's data to connect such user across multiple devices.</li>
-					<li>Precise Geographic Location data - allow processing of a user's precise geographic location data in support of a purpose for which that certain third party has consent.</li>
-				</ul>`
+				description: ''
 			}
 		},
 		vendors: {
@@ -212,7 +196,7 @@ export default {
 			detailLink: 'Informations et configuration',
 			who: {
 				title: 'Qui utilise mes données ?',
-				description: `Seulement nos partenaires et nous-même pouvons utiliser vos données. 
+				description: `Seulement nos partenaires et nous-même pouvons utiliser vos données.
 					Vous pouvez personnaliser vos choix ci-dessus ou continuer à utiliser notre site si vous êtes d'accord.`,
 				link: 'Voir la liste complète de nos partenaires'
 			},


### PR DESCRIPTION
This PR removes EN translation default wordings so that the default English language for purposes will come from the vendorlist.json. It also adds a few documentation notes emphasizing the importance of keeping translations up to date. 