### PR TITLE
fix localization capitalisation bug

### DIFF
--- a/src/lib/localize.js
+++ b/src/lib/localize.js
@@ -35,7 +35,7 @@ export class Localize {
 			const [language] = locale.toLowerCase().split('-');
 			return {
 				...acc,
-				[locale]: {
+				[locale.toLowerCase()]: {
 					...acc[locale],
 					...this.flattenObject(data[language]),
 					...this.flattenObject(data[locale])

--- a/src/lib/localize.test.js
+++ b/src/lib/localize.test.js
@@ -1,5 +1,4 @@
 /* eslint-disable max-nested-callbacks */
-import { expect } from 'chai';
 import {Localize} from './localize';
 
 describe('localize', () => {
@@ -18,7 +17,7 @@ describe('localize', () => {
 			prop5: 'prop5'
 		});
 
-		expect(result).to.deep.equal({
+		expect(result).toEqual({
 			'one.prop1': 'prop1',
 			'one.two.prop2': 'prop2',
 			'one.two.prop3': 'prop3',
@@ -28,5 +27,27 @@ describe('localize', () => {
 	});
 
 
+	it('keep override', () => {
+		const localization = {
+			en: {
+				prop1: 'prop1',
+				two: {
+					prop2: 'prop2',
+					prop3: 'prop3'
+				},
+				prop4: 'prop4'
+			},
+			'en-US': {
+				prop1: 'new prop1',
+			}
+		};
+		const localize = new Localize(localization);
+		expect(localize.localizedValues).toEqual({
+			'prop1': 'new prop1',
+			'two.prop2': 'prop2',
+			'two.prop3': 'prop3',
+			'prop4': 'prop4'
+		});
+	});
 
 });


### PR DESCRIPTION
As describe by the unit test, when we specify a `config.localization` settings with a capitalized locale `fr-FR` for example, the overridden configuration is not used. This commit fix it.